### PR TITLE
Clear each handler when it is called

### DIFF
--- a/src/logic/AddHandler.java
+++ b/src/logic/AddHandler.java
@@ -34,6 +34,7 @@ class AddHandler extends UndoableCommandHandler {
 
     @Override
     protected String execute(String command, String parameter, ArrayList<Task> taskList) {
+        reset();
         String[] token = parameter.split(" ");
         if (isHelpOnly(token) || isEmpty(parameter)) {
             return getHelp();
@@ -48,14 +49,14 @@ class AddHandler extends UndoableCommandHandler {
         assert (newTask != null);
         
         memory.addTask(newTask); 
-        recordMemoryChanges(taskList);       
+        recordChanges(taskList);       
         addLogger.log(Level.FINE, "Add sucess");
         return String.format(SUCCESS_ADD_MESSAGE, newTask.getDescription());
        
     }
 
     @Override
-    void recordMemoryChanges(ArrayList<Task> taskList) {
+    void recordChanges(ArrayList<Task> taskList) {
         UndoRedoRecorder addRecorder = new UndoRedoRecorder(taskList);
         addRecorder.appendAction(new UndoRedoAction(UndoRedoAction.ActionType.ADD, newTask, newTask));
         updateTaskList(taskList);     
@@ -64,6 +65,12 @@ class AddHandler extends UndoableCommandHandler {
        
     }
 
+    /**
+     * reset the handler when it is called
+     */
+    private void reset() {
+        newTask = null;
+    }
 
 
     /**

--- a/src/logic/AddHandler.java
+++ b/src/logic/AddHandler.java
@@ -54,7 +54,8 @@ class AddHandler extends UndoableCommandHandler {
        
     }
 
-    private void recordMemoryChanges(ArrayList<Task> taskList) {
+    @Override
+    void recordMemoryChanges(ArrayList<Task> taskList) {
         UndoRedoRecorder addRecorder = new UndoRedoRecorder(taskList);
         addRecorder.appendAction(new UndoRedoAction(UndoRedoAction.ActionType.ADD, newTask, newTask));
         updateTaskList(taskList);     

--- a/src/logic/ClearHandler.java
+++ b/src/logic/ClearHandler.java
@@ -33,7 +33,8 @@ class ClearHandler extends UndoableCommandHandler {
         return ALL_CLEAR_MESSAGE;
     }
     
-    private void recordMemoryChanges(ArrayList<Task> taskList) {
+    @Override
+    void recordMemoryChanges(ArrayList<Task> taskList) {
         UndoRedoRecorder clearRecorder = new UndoRedoRecorder(taskList);
         for (Task removedTask: oldTaskList) {
             clearRecorder.appendAction(new UndoRedoAction(UndoRedoAction.ActionType.DELETE, removedTask, removedTask));

--- a/src/logic/ClearHandler.java
+++ b/src/logic/ClearHandler.java
@@ -28,13 +28,13 @@ class ClearHandler extends UndoableCommandHandler {
     @Override
     protected String execute(String command, String parameter, ArrayList<Task> taskList) {
         oldTaskList = new ArrayList<Task>(taskList);
-        recordMemoryChanges(taskList);
+        recordChanges(taskList);
         memory.removeAll();
         return ALL_CLEAR_MESSAGE;
     }
     
     @Override
-    void recordMemoryChanges(ArrayList<Task> taskList) {
+    void recordChanges(ArrayList<Task> taskList) {
         UndoRedoRecorder clearRecorder = new UndoRedoRecorder(taskList);
         for (Task removedTask: oldTaskList) {
             clearRecorder.appendAction(new UndoRedoAction(UndoRedoAction.ActionType.DELETE, removedTask, removedTask));

--- a/src/logic/DeleteHandler.java
+++ b/src/logic/DeleteHandler.java
@@ -87,7 +87,8 @@ class DeleteHandler extends UndoableCommandHandler {
         return feedback;
     }
     
-    private void recordMemoryChanges(ArrayList<Task> taskList) {
+    @Override
+    void recordMemoryChanges(ArrayList<Task> taskList) {
         UndoRedoRecorder deleteRecorder = new UndoRedoRecorder(taskList);
         for (Task task: removedTask) {
             deleteRecorder.appendAction(new UndoRedoAction(UndoRedoAction.ActionType.DELETE, task, task));

--- a/src/logic/DeleteHandler.java
+++ b/src/logic/DeleteHandler.java
@@ -42,6 +42,7 @@ class DeleteHandler extends UndoableCommandHandler {
     protected String execute(String command, String parameter, ArrayList<Task> taskList) {
         deleteLogger.entering(getClass().getName(), "preparing for delete");
 
+        reset();
         String[] token = parameter.split(" ");
         if (isHelp(token) || isEmptyParameter(parameter)) {
             return getHelp();
@@ -55,7 +56,6 @@ class DeleteHandler extends UndoableCommandHandler {
         String goodFeedback = new String(), 
                 badFeedback = new String(),
                 feedback = new String();		
-
         for (String t: token) {
             IndexParser ip = new IndexParser(t);
             int index;
@@ -74,8 +74,7 @@ class DeleteHandler extends UndoableCommandHandler {
             } 
         }
 
-        recordMemoryChanges(taskList);
-        deleteTasks(taskList, removedTask);
+        recordChanges(taskList);
         
         if (!goodFeedback.equals("")) {
             feedback += String.format(GOODFEEDBACK_MESSAGE, goodFeedback);
@@ -88,31 +87,25 @@ class DeleteHandler extends UndoableCommandHandler {
     }
     
     @Override
-    void recordMemoryChanges(ArrayList<Task> taskList) {
+    void recordChanges(ArrayList<Task> taskList) {
         UndoRedoRecorder deleteRecorder = new UndoRedoRecorder(taskList);
         for (Task task: removedTask) {
             deleteRecorder.appendAction(new UndoRedoAction(UndoRedoAction.ActionType.DELETE, task, task));
+            taskList.remove(task);
+            memory.removeTask(task);
         }
         if (!deleteRecorder.isEmpty()) {
+            deleteRecorder.recordUpdatedList(taskList);
             undoRedoManager.addNewRecord(deleteRecorder);
         }
     }
 
-
-
     /**
-     * delete the tasks in taskList and memory
-     * @param taskList
-     * @param removedTask
+     * reset the status of handler
      */
-    private void deleteTasks(ArrayList<Task> taskList, ArrayList<Task> removedTask) {
-        for (Task task: removedTask) {
-            taskList.remove(task);
-            memory.removeTask(task);
-        }
+    private void reset() {
+        removedTask.clear();
     }
-
-
     /**
      * append the indexes for valid deletion or invalid input
      * @param goodFeedback

--- a/src/logic/EditDescriptionHandler.java
+++ b/src/logic/EditDescriptionHandler.java
@@ -66,8 +66,8 @@ class EditDescriptionHandler extends UndoableCommandHandler {
             Collections.sort(taskList, new TaskComparator());
 	    }
     }
-
-	private void recordMemoryChanges(ArrayList<Task> taskList) {
+    @Override
+    void recordMemoryChanges(ArrayList<Task> taskList) {
         UndoRedoRecorder editDescriptionRecorder = new UndoRedoRecorder(taskList);
         editDescriptionRecorder.appendAction(new UndoRedoAction(UndoRedoAction.ActionType.EDIT, oldTask, newTask));
         updateTaskList(taskList);

--- a/src/logic/EditDescriptionHandler.java
+++ b/src/logic/EditDescriptionHandler.java
@@ -31,6 +31,7 @@ class EditDescriptionHandler extends UndoableCommandHandler {
 	    
 	@Override
 	protected String execute(String command, String parameter, ArrayList<Task> taskList) {
+	    reset();
 		String[] token = parameter.split(" ");
 		if (token[0].toLowerCase().equals("help") || token[0].equals("")) {
 			return getHelp();
@@ -56,18 +57,30 @@ class EditDescriptionHandler extends UndoableCommandHandler {
 	    return "Changed " + oldTask.getDescription() + " to " +
 	    		newTask.getDescription() + "\n";
 	}
+	
+	/**
+     * reset the handler when it is called
+     */
+    private void reset() {
+        newTask = null;
+        oldTask = null;
+    }
 
 
+    /**
+     * Perform the edit in Memory
+     * @param taskList taskList shown to user
+     */
     private void performEdit(ArrayList<Task> taskList) {
         if ((newTask != oldTask) && (oldTask != null)) {
 	        memory.removeTask(oldTask);
 	        memory.addTask(newTask);
-            recordMemoryChanges(taskList);
+            recordChanges(taskList);
             Collections.sort(taskList, new TaskComparator());
 	    }
     }
     @Override
-    void recordMemoryChanges(ArrayList<Task> taskList) {
+    void recordChanges(ArrayList<Task> taskList) {
         UndoRedoRecorder editDescriptionRecorder = new UndoRedoRecorder(taskList);
         editDescriptionRecorder.appendAction(new UndoRedoAction(UndoRedoAction.ActionType.EDIT, oldTask, newTask));
         updateTaskList(taskList);

--- a/src/logic/EditHandler.java
+++ b/src/logic/EditHandler.java
@@ -39,8 +39,7 @@ class EditHandler extends UndoableCommandHandler {
 
     @Override
     protected String execute(String command, String parameter, ArrayList<Task> taskList) {
-        editLogger.entering(getClass().getName(), "preparing for editing tasks");
-
+        reset();
         String[] token = parameter.split(" ");
         if (isHelp(token) || isEmpty(parameter)) {
             return getHelp();
@@ -72,14 +71,14 @@ class EditHandler extends UndoableCommandHandler {
                 } catch (NumberFormatException nfe) {
                     editLogger.log(Level.WARNING, "Not a number entered for edit", nfe);
                     return INVALID_INDEX_MESSAGE;
-            }
+                }
 
-            try {
-                oldTask = taskList.remove(index);
-                newTask = CommandHandler.createNewTask(parameter.replaceFirst(token[0], "").trim());
-            } catch (IndexOutOfBoundsException iob) {
-                return INVALID_INDEX_MESSAGE;
-            }
+                try {
+                    oldTask = taskList.remove(index);
+                    newTask = CommandHandler.createNewTask(parameter.replaceFirst(token[0], "").trim());
+                } catch (IndexOutOfBoundsException iob) {
+                    return INVALID_INDEX_MESSAGE;
+                }
                 break;
         }
 
@@ -87,7 +86,14 @@ class EditHandler extends UndoableCommandHandler {
         return "";
     }
 
-
+    /**
+     * reset the handler when it is called
+     */
+    private void reset() {
+        newTask = null;
+        oldTask = null;
+    }
+    
     /**
      * execute the changes in Memory
      * @param taskList
@@ -96,7 +102,7 @@ class EditHandler extends UndoableCommandHandler {
         if (newTask != oldTask && oldTask != null) {
             memory.removeTask(oldTask);
             memory.addTask(newTask);
-            recordMemoryChanges(taskList);            
+            recordChanges(taskList);            
             Collections.sort(taskList, new TaskComparator());
         }
     }
@@ -107,7 +113,7 @@ class EditHandler extends UndoableCommandHandler {
     }
     
     @Override
-    void recordMemoryChanges(ArrayList<Task> taskList) {
+    void recordChanges(ArrayList<Task> taskList) {
         UndoRedoRecorder editRecorder = new UndoRedoRecorder(taskList);
         editRecorder.appendAction(new UndoRedoAction(UndoRedoAction.ActionType.EDIT, oldTask, newTask));
         updateTaskList(taskList);

--- a/src/logic/EditHandler.java
+++ b/src/logic/EditHandler.java
@@ -106,7 +106,8 @@ class EditHandler extends UndoableCommandHandler {
         taskList.add(newTask);
     }
     
-    private void recordMemoryChanges(ArrayList<Task> taskList) {
+    @Override
+    void recordMemoryChanges(ArrayList<Task> taskList) {
         UndoRedoRecorder editRecorder = new UndoRedoRecorder(taskList);
         editRecorder.appendAction(new UndoRedoAction(UndoRedoAction.ActionType.EDIT, oldTask, newTask));
         updateTaskList(taskList);

--- a/src/logic/EditTimeHandler.java
+++ b/src/logic/EditTimeHandler.java
@@ -31,6 +31,7 @@ class EditTimeHandler extends UndoableCommandHandler {
         
     @Override
     protected String execute(String command, String parameter, ArrayList<Task> taskList) {
+        reset();
     	String[] token = parameter.split(" ");
 		if (token[0].toLowerCase().equals("help") || token[0].equals("")) {
 			return getHelp();
@@ -67,18 +68,26 @@ class EditTimeHandler extends UndoableCommandHandler {
         if ((newTask != oldTask) && (oldTask != null)) {
             memory.removeTask(oldTask);
             memory.addTask(newTask);
-            recordMemoryChanges(taskList);
+            recordChanges(taskList);
             Collections.sort(taskList, new TaskComparator());
         }
     }
     
     @Override
-    void recordMemoryChanges(ArrayList<Task> taskList) {
+    void recordChanges(ArrayList<Task> taskList) {
         UndoRedoRecorder editTimeRecorder = new UndoRedoRecorder(taskList);
         editTimeRecorder.appendAction(new UndoRedoAction(UndoRedoAction.ActionType.EDIT, oldTask, newTask));
         updateTaskList(taskList);
         editTimeRecorder.recordUpdatedList(taskList);
         undoRedoManager.addNewRecord(editTimeRecorder);
+    }
+    
+    /**
+     * reset the handler when it is called
+     */
+    private void reset() {
+        newTask = null;
+        oldTask = null;
     }
     
     private void updateTaskList(ArrayList<Task> taskList) {

--- a/src/logic/EditTimeHandler.java
+++ b/src/logic/EditTimeHandler.java
@@ -72,7 +72,8 @@ class EditTimeHandler extends UndoableCommandHandler {
         }
     }
     
-    private void recordMemoryChanges(ArrayList<Task> taskList) {
+    @Override
+    void recordMemoryChanges(ArrayList<Task> taskList) {
         UndoRedoRecorder editTimeRecorder = new UndoRedoRecorder(taskList);
         editTimeRecorder.appendAction(new UndoRedoAction(UndoRedoAction.ActionType.EDIT, oldTask, newTask));
         updateTaskList(taskList);

--- a/src/logic/LogicController.java
+++ b/src/logic/LogicController.java
@@ -3,9 +3,10 @@ package logic;
 import java.util.regex.Pattern;
 import java.util.ArrayList;
 import java.util.Hashtable;
-
 import java.util.logging.Logger;
 import java.util.logging.Level;
+
+import parser.TaskTypeParser;
 import storage.Memory;
 import application.Task;
 
@@ -60,14 +61,24 @@ public class LogicController {
     public String executeCommand(String userCommand) {
         String command = userCommand.trim().split(" ")[0];
         
-        if (!handlerTable.containsKey(command)) {
-            return "Unknown command!\n";
+        if (isValidKeyword(command)) {
+            return executeAddByDefault(userCommand);            
         }
         
         CommandHandler handler = handlerTable.get(command);
                 
         String parameter = userCommand.replaceFirst(Pattern.quote(command), "").trim();
         return handler.execute(command, parameter, taskList);
+    }
+
+
+    private boolean isValidKeyword(String command) {
+        return !handlerTable.containsKey(command);
+    }
+
+
+    private String executeAddByDefault(String userCommand) {
+        return handlerTable.get("add").execute("add", userCommand, taskList);
     }
 
     /**

--- a/src/logic/MarkHandler.java
+++ b/src/logic/MarkHandler.java
@@ -32,6 +32,7 @@ class MarkHandler extends UndoableCommandHandler {
 
     @Override
     protected String execute(String command, String parameter, ArrayList<Task> taskList) {
+        reset();
         markLogger.entering(getClass().getName(), "Entering marking");
 
         String[] token = parameter.split(" ");
@@ -63,7 +64,12 @@ class MarkHandler extends UndoableCommandHandler {
         return String.format(MARKED_MESSAGE, goodFeedback);
     }
 
-   
+    /**
+     * reset the handler when it is called
+     */
+    private void reset() {
+        markedTask.clear();
+    }
 
     /**
      * check if the argument user typed is empty
@@ -89,7 +95,7 @@ class MarkHandler extends UndoableCommandHandler {
     }
     
     @Override
-    void recordMemoryChanges(ArrayList<Task> taskList) {
+    void recordChanges(ArrayList<Task> taskList) {
         
     }
 }

--- a/src/logic/MarkHandler.java
+++ b/src/logic/MarkHandler.java
@@ -87,4 +87,9 @@ class MarkHandler extends UndoableCommandHandler {
     public String getHelp() {
         return HELP_MESSAGE;
     }
+    
+    @Override
+    void recordMemoryChanges(ArrayList<Task> taskList) {
+        
+    }
 }

--- a/src/logic/RedoHandler.java
+++ b/src/logic/RedoHandler.java
@@ -47,7 +47,7 @@ class RedoHandler extends UndoableCommandHandler {
     }
     
     @Override
-    void recordMemoryChanges(ArrayList<Task> taskList) {
+    void recordChanges(ArrayList<Task> taskList) {
         
     }
 }

--- a/src/logic/RedoHandler.java
+++ b/src/logic/RedoHandler.java
@@ -45,4 +45,9 @@ class RedoHandler extends UndoableCommandHandler {
         // TODO Auto-generated method stub
         return "redo\n\t discard the undo actions";
     }
+    
+    @Override
+    void recordMemoryChanges(ArrayList<Task> taskList) {
+        
+    }
 }

--- a/src/logic/SetLocationHandler.java
+++ b/src/logic/SetLocationHandler.java
@@ -36,5 +36,9 @@ public class SetLocationHandler extends UndoableCommandHandler {
         return "setlocation <path>\n\t set the directory that tasks will be saved to\n";
     }
 
+    @Override
+    void recordMemoryChanges(ArrayList<Task> taskList) {
+        
+    }
     
 }

--- a/src/logic/SetLocationHandler.java
+++ b/src/logic/SetLocationHandler.java
@@ -37,7 +37,7 @@ public class SetLocationHandler extends UndoableCommandHandler {
     }
 
     @Override
-    void recordMemoryChanges(ArrayList<Task> taskList) {
+    void recordChanges(ArrayList<Task> taskList) {
         
     }
     

--- a/src/logic/UndoHandler.java
+++ b/src/logic/UndoHandler.java
@@ -46,4 +46,9 @@ class UndoHandler extends UndoableCommandHandler {
         // TODO Auto-generated method stub
         return "undo\n\t revoke latest change";
     }
+    
+    @Override
+    void recordMemoryChanges(ArrayList<Task> taskList) {
+        
+    }
 }

--- a/src/logic/UndoHandler.java
+++ b/src/logic/UndoHandler.java
@@ -48,7 +48,7 @@ class UndoHandler extends UndoableCommandHandler {
     }
     
     @Override
-    void recordMemoryChanges(ArrayList<Task> taskList) {
+    void recordChanges(ArrayList<Task> taskList) {
         
     }
 }

--- a/src/logic/UndoRedoRecorder.java
+++ b/src/logic/UndoRedoRecorder.java
@@ -2,6 +2,7 @@
 package logic;
 
 import java.util.ArrayList;
+import java.util.Stack;
 import application.Task;
 /**
  * This class records all the actions performed during each single
@@ -14,7 +15,7 @@ import application.Task;
  */
 public class UndoRedoRecorder {
 
-    private ArrayList<UndoRedoAction> actionList = new ArrayList<UndoRedoAction>();
+    private Stack<UndoRedoAction> actionList = new Stack<UndoRedoAction>();
     private ArrayList<Task> currentTaskList = new ArrayList<Task>();
     private ArrayList<Task> changedTaskList = new ArrayList<Task>();
     
@@ -28,7 +29,7 @@ public class UndoRedoRecorder {
         changedTaskList.addAll(updatedList);
     }
     public void appendAction(UndoRedoAction newAction) {
-        actionList.add(newAction);
+        actionList.push(newAction);
     }
     
     public ArrayList<Task> getCurrentTaskList() {

--- a/src/logic/UndoableCommandHandler.java
+++ b/src/logic/UndoableCommandHandler.java
@@ -18,4 +18,5 @@ abstract class UndoableCommandHandler extends CommandHandler {
     @Override
     abstract public String getHelp();
 
+    abstract void recordMemoryChanges(ArrayList<Task> taskList);
 }

--- a/src/logic/UndoableCommandHandler.java
+++ b/src/logic/UndoableCommandHandler.java
@@ -18,5 +18,5 @@ abstract class UndoableCommandHandler extends CommandHandler {
     @Override
     abstract public String getHelp();
 
-    abstract void recordMemoryChanges(ArrayList<Task> taskList);
+    abstract void recordChanges(ArrayList<Task> taskList);
 }


### PR DESCRIPTION
this prevents repeated records of actions, such as undo will redo delete of a same task twice.
